### PR TITLE
:bug: changed getter darkTheme to always return darkTheme and added getter lightTheme

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -7,25 +7,25 @@
 
 <!--
 
-We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
+adding an additional getter lightTheme and changing the getter darkTheme to always returning the dark theme instead of returning the current theme.
 
 -->
 
 ### Alternate Designs
 
-<!-- Explain what other alternates were considered and why the proposed version was selected -->
+<!-- instead of the additional getter, the getter theme could alway return the lightTheme -->
 
 ### Why Should This Be In Core?
 
-<!-- Explain why this functionality should be in atom/atom as opposed to a package -->
+<!-- mode independend getter for the modes are necesseray, if you need it for example in a theme settings screen -->
 
 ### Benefits
 
-<!-- What benefits will be realized by the code change? -->
+<!-- usability improved in case of theme setting screens -->
 
 ### Possible Drawbacks
 
-<!-- What are the possible side-effects or negative impacts of the code change? -->
+<!-- not known -->
 
 ### Verification Process
 
@@ -33,14 +33,12 @@ We must be able to understand the design of your change from this description. I
 
 What process did you follow to verify that your change has the desired effects?
 
-- How did you verify that all new functionality works as expected?
-- How did you verify that all changed functionality works as expected?
-- How did you verify that the change has not introduced any regressions?
+- manual test with example
 
-Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.
+manually compared the themes from getter lightTheme and darkTheme
 
 -->
 
 ### Applicable Issues
 
-<!-- Enter any applicable Issues here -->
+<!-- not known -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -7,25 +7,25 @@
 
 <!--
 
-adding an additional getter lightTheme and changing the getter darkTheme to always returning the dark theme instead of returning the current theme.
+We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
 
 -->
 
 ### Alternate Designs
 
-<!-- instead of the additional getter, the getter theme could alway return the lightTheme -->
+<!-- Explain what other alternates were considered and why the proposed version was selected -->
 
 ### Why Should This Be In Core?
 
-<!-- mode independend getter for the modes are necesseray, if you need it for example in a theme settings screen -->
+<!-- Explain why this functionality should be in atom/atom as opposed to a package -->
 
 ### Benefits
 
-<!-- usability improved in case of theme setting screens -->
+<!-- What benefits will be realized by the code change? -->
 
 ### Possible Drawbacks
 
-<!-- not known -->
+<!-- What are the possible side-effects or negative impacts of the code change? -->
 
 ### Verification Process
 
@@ -33,12 +33,14 @@ adding an additional getter lightTheme and changing the getter darkTheme to alwa
 
 What process did you follow to verify that your change has the desired effects?
 
-- manual test with example
+- How did you verify that all new functionality works as expected?
+- How did you verify that all changed functionality works as expected?
+- How did you verify that the change has not introduced any regressions?
 
-manually compared the themes from getter lightTheme and darkTheme
+Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.
 
 -->
 
 ### Applicable Issues
 
-<!-- not known -->
+<!-- Enter any applicable Issues here -->

--- a/lib/src/adaptive_theme.dart
+++ b/lib/src/adaptive_theme.dart
@@ -118,7 +118,10 @@ class _AdaptiveThemeState extends State<AdaptiveTheme>
   ThemeData get theme => _preferences.mode.isDark ? _darkTheme : _theme;
 
   @override
-  ThemeData get darkTheme => _preferences.mode.isLight ? _theme : _darkTheme;
+  ThemeData get lightTheme => _theme;
+
+  @override
+  ThemeData get darkTheme => _darkTheme;
 
   @override
   AdaptiveThemeMode get mode => _preferences.mode;

--- a/lib/src/adaptive_theme_manager.dart
+++ b/lib/src/adaptive_theme_manager.dart
@@ -20,10 +20,13 @@ part of adaptive_theme;
 /// from [AdaptiveTheme].
 /// An instance of this can be retrieved by calling [AdaptiveTheme.of].
 abstract class AdaptiveThemeManager {
-  /// provides current the light theme
+  /// provides current theme
   ThemeData get theme;
 
-  /// provides the dart theme
+  /// provides the light theme
+  ThemeData get lightTheme;
+
+  /// provides the dark theme
   ThemeData get darkTheme;
 
   /// Returns current theme mode


### PR DESCRIPTION
### Description of the Change
adding an additional getter lightTheme and changing the getter darkTheme to always returning the dark theme instead of returning the current theme.

### Alternate Designs
instead of the additional getter, the getter theme could alway return the lightTheme

### Why Should This Be In Core?
mode independend getter for the modes are necesseray, if you need it for example in a theme settings screen

### Benefits
usability improved in case of theme setting screens

### Possible Drawbacks
not known

### Verification Process
What process did you follow to verify that your change has the desired effects?

- manual test with example
   manually compared the themes from getter lightTheme and darkTheme

### Applicable Issues
not known 
