### PR TITLE
Fix Cupertino theme changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,6 @@ class MyApp extends StatelessWidget {
       builder: (theme) => CupertinoApp(
         title: 'Adaptive Theme Demo',
         theme: theme,
-        darkTheme: darkTheme,
         home: MyHomePage(),
       ),
     );

--- a/lib/src/cupertino_adaptive_theme.dart
+++ b/lib/src/cupertino_adaptive_theme.dart
@@ -119,6 +119,15 @@ class _CupertinoAdaptiveThemeState extends State<CupertinoAdaptiveTheme>
   }
 
   @override
+  void initState() {
+    super.initState();
+
+    WidgetsBinding.instance?.window.onPlatformBrightnessChanged = () {
+      this.setSystem();
+    };
+  }
+
+  @override
   ValueNotifier<AdaptiveThemeMode> get modeChangeNotifier =>
       _modeChangeNotifier;
 
@@ -206,8 +215,14 @@ class _CupertinoAdaptiveThemeState extends State<CupertinoAdaptiveTheme>
   }
 
   @override
-  Widget build(BuildContext context) =>
-      widget.builder(_preferences.mode.isLight ? _theme : _darkTheme);
+  Widget build(BuildContext context) {
+    final isLight = _preferences.mode.isLight ||
+        (_preferences.mode.isSystem &&
+            WidgetsBinding.instance?.window.platformBrightness ==
+                Brightness.light);
+
+    return widget.builder(isLight ? _theme : _darkTheme);
+  }
 
   @override
   void dispose() {


### PR DESCRIPTION
### Requirements

None.

### Description of the Change

I have noticed that, with CupertinoApp, whenever you switched light/dark theme, the application did not update the theme. Moreover, setting "initial" to "AdaptiveMode.system", the app always started in dark mode despite the light mode on the device.
I have made three mayors updates:
1. In the CupertinoAdaptiveTheme's build method it now checks whether the theme is light because intentionally set white or because was set system and the device is in light mode. Giving that, the app is fully capable to detect the correct theme to set.
2. I have created an initState method in CupertinoAdaptiveTheme that set an onPlatformBrightnessChanged method in order to catch the variation of the light/dark mode and so update accordingly.
3. I have updated the README since there was a mistake: CupertinoApp does not have a "darkMode" property to be set.
