### PR TITLE
Feature/generic refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 3.1.0 (Unreleased)
+
+- `CupertinoAdaptiveThemeManager` is now deprecated and replaced with `AdaptiveThemeManager<CupertinoThemeData>` in
+  favor of supporting theming for other UI frameworks. (e.g. Fluent UI). This will be removed in `v4.0.0`.
+- `AdaptiveThemeManager` is now generic typed where the generic type represents the type of the theme data object.
+  Replace `AdaptiveThemeManager` with `AdaptiveThemeManager<ThemeData>`
+- `AdaptiveThemeManager` is now a **mixin** instead of **an abstract class** to reduce code duplication.
+
 # 3.0.0
 
 - Upgrade to Flutter 3.
@@ -28,18 +36,22 @@
 
 # 2.1.1
 
-- Fixed [#18](https://github.com/BirjuVachhani/adaptive_theme/issues/18) - Dark theme not working properly on all platforms.
+- Fixed [#18](https://github.com/BirjuVachhani/adaptive_theme/issues/18) - Dark theme not working properly on all
+  platforms.
 
 ## 2.1.0
 
-- Fixed [#16](https://github.com/BirjuVachhani/adaptive_theme/issues/16) - get theme and get darkTheme returns the same theme depended on mode
+- Fixed [#16](https://github.com/BirjuVachhani/adaptive_theme/issues/16) - get theme and get darkTheme returns the same
+  theme depended on mode
 - Added [#15](https://github.com/BirjuVachhani/adaptive_theme/issues/15) - Notify listener when changing theme mode
 
 ## 2.0.0
 
 - Improved documentation
 - Stable null safety support
-- Calling `AdaptiveTheme.of(context).toggleThemeMode()` now will sequentially loop through `AdaptiveThemeMode.light`, `AdaptiveThemeMode.dark` and `AdaptiveThemeMode.system` instead of just `AdaptiveThemeMode.light` and `AdaptiveThemeMode.dark`.
+- Calling `AdaptiveTheme.of(context).toggleThemeMode()` now will sequentially loop through `AdaptiveThemeMode.light`
+  , `AdaptiveThemeMode.dark` and `AdaptiveThemeMode.system` instead of just `AdaptiveThemeMode.light`
+  and `AdaptiveThemeMode.dark`.
 
 ## 2.0.0-nullsafety.1
 
@@ -49,7 +61,8 @@
 
 - Removed hard coded `shared_preferences` version.
 - Hide public constructors for `ThemePreferences`.
-- `AdaptiveTheme.of()` now returns instance of `AdaptiveThemeManager` instead of `AdaptiveThemeState` to set restrictions for accessing state directly.
+- `AdaptiveTheme.of()` now returns instance of `AdaptiveThemeManager` instead of `AdaptiveThemeState` to set
+  restrictions for accessing state directly.
 
 ## 1.0.0
 

--- a/lib/adaptive_theme.dart
+++ b/lib/adaptive_theme.dart
@@ -19,5 +19,6 @@ library adaptive_theme;
 export 'src/adaptive_theme.dart';
 export 'src/adaptive_theme_manager.dart';
 export 'src/adaptive_theme_mode.dart';
+export 'src/adaptive_theme_preferences.dart';
 export 'src/cupertino_adaptive_theme.dart';
 export 'src/cupertino_adaptive_theme_manager.dart';

--- a/lib/adaptive_theme.dart
+++ b/lib/adaptive_theme.dart
@@ -19,6 +19,5 @@ library adaptive_theme;
 export 'src/adaptive_theme.dart';
 export 'src/adaptive_theme_manager.dart';
 export 'src/adaptive_theme_mode.dart';
-export 'src/adaptive_theme_preferences.dart';
 export 'src/cupertino_adaptive_theme.dart';
 export 'src/cupertino_adaptive_theme_manager.dart';

--- a/lib/src/adaptive_theme.dart
+++ b/lib/src/adaptive_theme.dart
@@ -72,17 +72,17 @@ class AdaptiveTheme extends StatefulWidget {
 
   /// Returns reference of the [AdaptiveThemeManager] which allows access of
   /// the state object of [AdaptiveTheme] in a restrictive way.
-  static AdaptiveThemeManager of(BuildContext context) =>
+  static AdaptiveThemeManager<ThemeData> of(BuildContext context) =>
       context.findAncestorStateOfType<State<AdaptiveTheme>>()!
-          as AdaptiveThemeManager;
+          as AdaptiveThemeManager<ThemeData>;
 
   /// Returns reference of the [AdaptiveThemeManager] which allows access of
   /// the state object of [AdaptiveTheme] in a restrictive way.
   /// This returns null if the state instance of [AdaptiveTheme] is not found.
-  static AdaptiveThemeManager? maybeOf(BuildContext context) {
+  static AdaptiveThemeManager<ThemeData>? maybeOf(BuildContext context) {
     final state = context.findAncestorStateOfType<State<AdaptiveTheme>>();
     if (state == null) return null;
-    return state as AdaptiveThemeManager;
+    return state as AdaptiveThemeManager<ThemeData>;
   }
 
   /// returns most recent theme mode. This can be used to eagerly get previous
@@ -93,8 +93,7 @@ class AdaptiveTheme extends StatefulWidget {
 }
 
 class _AdaptiveThemeState extends State<AdaptiveTheme>
-    with WidgetsBindingObserver
-    implements AdaptiveThemeManager {
+    with WidgetsBindingObserver, AdaptiveThemeManager<ThemeData> {
   late ThemeData _theme;
   late ThemeData _darkTheme;
   late ThemePreferences _preferences;
@@ -160,15 +159,6 @@ class _AdaptiveThemeState extends State<AdaptiveTheme>
   Brightness get brightness => theme.brightness;
 
   @override
-  void setLight() => setThemeMode(AdaptiveThemeMode.light);
-
-  @override
-  void setDark() => setThemeMode(AdaptiveThemeMode.dark);
-
-  @override
-  void setSystem() => setThemeMode(AdaptiveThemeMode.system);
-
-  @override
   void setThemeMode(AdaptiveThemeMode mode) {
     _preferences.mode = mode;
     if (mounted) setState(() {});
@@ -185,13 +175,6 @@ class _AdaptiveThemeState extends State<AdaptiveTheme>
     _theme = light;
     if (dark != null) _darkTheme = dark;
     if (notify && mounted) setState(() {});
-  }
-
-  @override
-  void toggleThemeMode() {
-    final nextModeIndex = (mode.index + 1) % AdaptiveThemeMode.values.length;
-    final nextMode = AdaptiveThemeMode.values[nextModeIndex];
-    setThemeMode(nextMode);
   }
 
   @override

--- a/lib/src/adaptive_theme_manager.dart
+++ b/lib/src/adaptive_theme_manager.dart
@@ -21,15 +21,15 @@ import 'adaptive_theme_mode.dart';
 /// Entry point to change/modify theme or access theme related information
 /// from [AdaptiveTheme].
 /// An instance of this can be retrieved by calling [AdaptiveTheme.of].
-abstract class AdaptiveThemeManager {
+mixin AdaptiveThemeManager<T extends Object> {
   /// provides current theme
-  ThemeData get theme;
+  T get theme;
 
   /// provides the light theme
-  ThemeData get lightTheme;
+  T get lightTheme;
 
   /// provides the dark theme
-  ThemeData get darkTheme;
+  T get darkTheme;
 
   /// Returns current theme mode
   AdaptiveThemeMode get mode;
@@ -43,19 +43,19 @@ abstract class AdaptiveThemeManager {
   bool get isDefault;
 
   /// provides brightness of the current theme
-  Brightness get brightness;
+  Brightness? get brightness;
 
   /// Sets light theme as current
   /// Uses [AdaptiveThemeMode.light].
-  void setLight();
+  void setLight() => setThemeMode(AdaptiveThemeMode.light);
 
   /// Sets dark theme as current
   /// Uses [AdaptiveThemeMode.dark].
-  void setDark();
+  void setDark() => setThemeMode(AdaptiveThemeMode.dark);
 
   /// Sets theme based on the theme of the underlying OS.
   /// Uses [AdaptiveThemeMode.system].
-  void setSystem();
+  void setSystem() => setThemeMode(AdaptiveThemeMode.system);
 
   /// Allows to set/change theme mode.
   void setThemeMode(AdaptiveThemeMode mode);
@@ -63,14 +63,18 @@ abstract class AdaptiveThemeManager {
   /// Allows to set/change the entire theme.
   /// [notify] when set to true, will update the UI to use the new theme..
   void setTheme({
-    required ThemeData light,
-    ThemeData? dark,
+    required T light,
+    T? dark,
     bool notify = true,
   });
 
   /// Allows to toggle between theme modes [AdaptiveThemeMode.light],
   /// [AdaptiveThemeMode.dark] and [AdaptiveThemeMode.system].
-  void toggleThemeMode();
+  void toggleThemeMode() {
+    final nextModeIndex = (mode.index + 1) % AdaptiveThemeMode.values.length;
+    final nextMode = AdaptiveThemeMode.values[nextModeIndex];
+    setThemeMode(nextMode);
+  }
 
   /// Saves the configuration to the shared-preferences. This can be useful
   /// when you want to persist theme settings after clearing

--- a/lib/src/adaptive_theme_preferences.dart
+++ b/lib/src/adaptive_theme_preferences.dart
@@ -27,8 +27,10 @@ class ThemePreferences {
   late AdaptiveThemeMode mode;
   late AdaptiveThemeMode defaultMode;
 
-  ThemePreferences.initial({this.mode = AdaptiveThemeMode.light})
-      : defaultMode = mode;
+  ThemePreferences._(this.mode, this.defaultMode);
+
+  ThemePreferences.initial({AdaptiveThemeMode mode = AdaptiveThemeMode.light})
+      : this._(mode, mode);
 
   void reset() => mode = defaultMode;
 

--- a/lib/src/cupertino_adaptive_theme.dart
+++ b/lib/src/cupertino_adaptive_theme.dart
@@ -17,9 +17,9 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/scheduler.dart';
 
+import 'adaptive_theme_manager.dart';
 import 'adaptive_theme_mode.dart';
 import 'adaptive_theme_preferences.dart';
-import 'cupertino_adaptive_theme_manager.dart';
 
 /// Builder function to build themed widgets
 typedef CupertinoAdaptiveThemeBuilder = Widget Function(
@@ -73,18 +73,21 @@ class CupertinoAdaptiveTheme extends StatefulWidget {
 
   /// Returns reference of the [CupertinoAdaptiveThemeManager] which allows access of
   /// the state object of [CupertinoAdaptiveTheme] in a restrictive way.
-  static CupertinoAdaptiveThemeManager of(BuildContext context) =>
+  static AdaptiveThemeManager<CupertinoThemeData> of(BuildContext context) =>
       context.findAncestorStateOfType<State<CupertinoAdaptiveTheme>>()!
-          as CupertinoAdaptiveThemeManager;
+          as AdaptiveThemeManager<CupertinoThemeData>;
 
   /// Returns reference of the [CupertinoAdaptiveThemeManager] which allows access of
   /// the state object of [CupertinoAdaptiveTheme] in a restrictive way.
   /// This returns null if the state instance of [CupertinoAdaptiveTheme] is not found.
-  static CupertinoAdaptiveThemeManager? maybeOf(BuildContext context) {
+  static AdaptiveThemeManager<CupertinoThemeData>? maybeOf(
+      BuildContext context) {
     final state =
         context.findAncestorStateOfType<State<CupertinoAdaptiveTheme>>();
-    if (state == null || state is! CupertinoAdaptiveThemeManager) return null;
-    return state as CupertinoAdaptiveThemeManager;
+    if (state == null || state is! AdaptiveThemeManager<CupertinoThemeData>) {
+      return null;
+    }
+    return state as AdaptiveThemeManager<CupertinoThemeData>;
   }
 
   /// returns most recent theme mode. This can be used to eagerly get previous
@@ -95,8 +98,7 @@ class CupertinoAdaptiveTheme extends StatefulWidget {
 }
 
 class _CupertinoAdaptiveThemeState extends State<CupertinoAdaptiveTheme>
-    with WidgetsBindingObserver
-    implements CupertinoAdaptiveThemeManager {
+    with WidgetsBindingObserver, AdaptiveThemeManager<CupertinoThemeData> {
   late CupertinoThemeData _theme;
   late CupertinoThemeData _darkTheme;
   late ThemePreferences _preferences;
@@ -165,15 +167,6 @@ class _CupertinoAdaptiveThemeState extends State<CupertinoAdaptiveTheme>
   Brightness? get brightness => theme.brightness;
 
   @override
-  void setLight() => setThemeMode(AdaptiveThemeMode.light);
-
-  @override
-  void setDark() => setThemeMode(AdaptiveThemeMode.dark);
-
-  @override
-  void setSystem() => setThemeMode(AdaptiveThemeMode.system);
-
-  @override
   void setThemeMode(AdaptiveThemeMode mode) {
     _preferences.mode = mode;
     if (mounted) setState(() {});
@@ -190,13 +183,6 @@ class _CupertinoAdaptiveThemeState extends State<CupertinoAdaptiveTheme>
     _theme = light;
     if (dark != null) _darkTheme = dark;
     if (notify && mounted) setState(() {});
-  }
-
-  @override
-  void toggleThemeMode() {
-    final nextModeIndex = (mode.index + 1) % AdaptiveThemeMode.values.length;
-    final nextMode = AdaptiveThemeMode.values[nextModeIndex];
-    setThemeMode(nextMode);
   }
 
   @override

--- a/lib/src/cupertino_adaptive_theme_manager.dart
+++ b/lib/src/cupertino_adaptive_theme_manager.dart
@@ -16,73 +16,8 @@
 
 import 'package:flutter/cupertino.dart';
 
-import 'adaptive_theme_mode.dart';
+import 'adaptive_theme_manager.dart';
 
-/// Entry point to change/modify theme or access theme related information
-/// from [CupertinoAdaptiveTheme].
-/// An instance of this can be retrieved by calling [CupertinoAdaptiveTheme.of].
-abstract class CupertinoAdaptiveThemeManager {
-  /// provides current theme
-  CupertinoThemeData get theme;
-
-  /// provides the light theme
-  CupertinoThemeData get lightTheme;
-
-  /// provides the dark theme
-  CupertinoThemeData get darkTheme;
-
-  /// Returns current theme mode
-  AdaptiveThemeMode get mode;
-
-  /// Allows to listen to changes in them mode.
-  ValueNotifier<AdaptiveThemeMode> get modeChangeNotifier;
-
-  /// checks whether current theme is default theme or not. Default theme
-  /// refers to he themes provided at the time of initialization
-  /// of [CupertinoApp].
-  bool get isDefault;
-
-  /// provides brightness of the current theme
-  Brightness? get brightness;
-
-  /// Sets light theme as current
-  /// Uses [AdaptiveThemeMode.light].
-  void setLight();
-
-  /// Sets dark theme as current
-  /// Uses [AdaptiveThemeMode.dark].
-  void setDark();
-
-  /// Sets theme based on the theme of the underlying OS.
-  /// Uses [AdaptiveThemeMode.system].
-  void setSystem();
-
-  /// Allows to set/change theme mode.
-  void setThemeMode(AdaptiveThemeMode mode);
-
-  /// Allows to set/change the entire theme.
-  /// [notify] when set to true, will update the UI to use the new theme.
-  void setTheme({
-    required CupertinoThemeData light,
-    CupertinoThemeData? dark,
-    bool notify = true,
-  });
-
-  /// Allows to toggle between theme modes [AdaptiveThemeMode.light],
-  /// [AdaptiveThemeMode.dark] and [AdaptiveThemeMode.system].
-  void toggleThemeMode();
-
-  /// Saves the configuration to the shared-preferences. This can be useful
-  /// when you want to persist theme settings after clearing
-  /// shared-preferences. e.g. when user logs out, usually, preferences
-  /// are cleared. Call this method after clearing preferences to
-  /// persist theme mode.
-  Future<bool> persist();
-
-  /// Resets configuration to default configuration which has been provided
-  /// while initializing [CupertinoApp].
-  /// If [setTheme] method has been called with [isDefault] to true, Calling
-  /// this method afterwards will use theme provided by [setTheme] as default
-  /// themes.
-  Future<bool> reset();
-}
+@Deprecated('Use AdaptiveThemeManager<CupertinoThemeData> instead.')
+typedef CupertinoAdaptiveThemeManager
+    = AdaptiveThemeManager<CupertinoThemeData>;

--- a/test/cupertino_adaptive_theme_test.dart
+++ b/test/cupertino_adaptive_theme_test.dart
@@ -90,14 +90,14 @@ void main() {
 
     BuildContext context = tester.element(find.byType(CupertinoPageScaffold));
     expect(CupertinoAdaptiveTheme.of(context),
-        isA<CupertinoAdaptiveThemeManager>(),
+        isA<AdaptiveThemeManager<CupertinoThemeData>>(),
         reason:
             'CupertinoAdaptiveTheme.of should return instance of CupertinoAdaptiveThemeManager but actually returned something else.');
     expect(CupertinoAdaptiveTheme.maybeOf(context), isNotNull,
         reason:
             'CupertinoAdaptiveTheme.maybeOf should not return null but it did.');
     expect(CupertinoAdaptiveTheme.maybeOf(context),
-        isA<CupertinoAdaptiveThemeManager>(),
+        isA<AdaptiveThemeManager<CupertinoThemeData>>(),
         reason:
             'CupertinoAdaptiveTheme.maybeOf should return instance of CupertinoAdaptiveThemeManager but actually returned something else.');
 


### PR DESCRIPTION
### Summary

This lays out ground work for supporting custom ui libraries (e.g. Fluent UI).

- `CupertinoAdaptiveThemeManager` is now deprecated and replaced with `AdaptiveThemeManager<CupertinoThemeData>` in
  favor of supporting theming for other UI frameworks. (e.g. Fluent UI). This will be removed in `v4.0.0`.
- `AdaptiveThemeManager` is now generic typed where the generic type represents the type of the theme data object.
  Replace `AdaptiveThemeManager` with `AdaptiveThemeManager<ThemeData>`
- `AdaptiveThemeManager` is now a **mixin** instead of **an abstract class** to reduce code duplication.
