### PR TITLE
Fix incorrect CupertinoApp example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,6 @@ class MyApp extends StatelessWidget {
       builder: (theme) => CupertinoApp(
         title: 'Adaptive Theme Demo',
         theme: theme,
-        darkTheme: darkTheme,
         home: MyHomePage(),
       ),
     );


### PR DESCRIPTION
CupertinoApp has no darkTheme parameter

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The README section under “Using CupertinoTheme” contains an incorrect example that uses:

`darkTheme: darkTheme,`

However, CupertinoApp does not support a darkTheme parameter.
This causes confusion for users and leads to compilation errors when copying the example.

This PR updates the README by removing the unsupported parameter and providing a correct CupertinoApp usage example.

### Alternate Designs

No alternate designs were needed.
The documentation fix is straightforward simply removing the invalid parameter to match the actual Flutter API.

### Why Should This Be In Core?

This is a documentation correction that prevents:

- build failures
- confusion for new users
- incorrect usage of the package

Since developers frequently copy code samples from the README, it is important the examples be accurate.

### Benefits

- Provides accurate CupertinoApp usage
- Prevents compile-time errors
- Improves developer experience when integrating adaptive_theme
- Ensures consistency with current Flutter API

### Possible Drawbacks

There are no drawbacks this change only updates documentation and does not affect the package codebase or behavior.

### Verification Process

I reviewed the example app and inspected the `CupertinoApp` implementation. The Flutter SDK confirms that `CupertinoApp` does not include a `darkTheme` parameter. This validates that the README example is incorrect, and removing the parameter results in accurate, compilable code.

### Applicable Issues

No formal issue exists, but the incorrect code sample causes predictable compile time errors.
